### PR TITLE
Add static map comparison site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # map-compare
-Website to compare the size of different geographical area around the world
+
+This project provides a small static website that helps comparing two places of the world side by side. The maps are powered by Leaflet with OpenStreetMap tiles.
+
+## Usage
+
+Open `index.html` directly in a browser or host the repository with any static hosting solution such as GitHub Pages. The URL keeps the current map positions so copy‑pasting the address bar will restore the same views.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,105 @@
+let syncZoom = true;
+let movingMap1 = false;
+let movingMap2 = false;
+
+function parsePosition(param) {
+  if (!param) return null;
+  const parts = param.split(',').map(Number);
+  if (parts.length === 3 && parts.every(p => !isNaN(p))) {
+    return {lat: parts[0], lng: parts[1], zoom: parts[2]};
+  }
+  return null;
+}
+
+function updateUrl() {
+  const url = new URL(window.location);
+  const c1 = map1.getCenter();
+  const z1 = map1.getZoom();
+  const c2 = map2.getCenter();
+  const z2 = map2.getZoom();
+  url.searchParams.set('map1', `${c1.lat.toFixed(4)},${c1.lng.toFixed(4)},${z1}`);
+  url.searchParams.set('map2', `${c2.lat.toFixed(4)},${c2.lng.toFixed(4)},${z2}`);
+  url.searchParams.set('sync', syncZoom ? '1' : '0');
+  history.replaceState(null, '', url);
+}
+
+const params = new URLSearchParams(window.location.search);
+const pos1 = parsePosition(params.get('map1')) || {lat: 0, lng: 0, zoom: 2};
+const pos2 = parsePosition(params.get('map2')) || pos1;
+syncZoom = params.get('sync') !== '0';
+
+const map1 = L.map('map1').setView([pos1.lat, pos1.lng], pos1.zoom);
+const map2 = L.map('map2').setView([pos2.lat, pos2.lng], pos2.zoom);
+
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '© OpenStreetMap contributors'
+}).addTo(map1);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '© OpenStreetMap contributors'
+}).addTo(map2);
+
+const drawnItems1 = new L.FeatureGroup();
+map1.addLayer(drawnItems1);
+const drawnItems2 = new L.FeatureGroup();
+map2.addLayer(drawnItems2);
+
+const drawControl = new L.Control.Draw({
+  edit: {
+    featureGroup: drawnItems1
+  }
+});
+map1.addControl(drawControl);
+
+map1.on(L.Draw.Event.CREATED, function (event) {
+  const layer = event.layer;
+  drawnItems1.addLayer(layer);
+  const geo = layer.toGeoJSON();
+  const clone = L.geoJSON(geo);
+  drawnItems2.addLayer(clone);
+});
+
+function clearDrawings() {
+  drawnItems1.clearLayers();
+  drawnItems2.clearLayers();
+}
+
+document.getElementById('clear').addEventListener('click', clearDrawings);
+
+function syncMap2() {
+  if (movingMap1) return;
+  movingMap2 = true;
+  map2.setView(map1.getCenter(), map1.getZoom());
+  movingMap2 = false;
+}
+
+function syncMap1() {
+  if (movingMap2) return;
+  movingMap1 = true;
+  map1.setView(map2.getCenter(), map2.getZoom());
+  movingMap1 = false;
+}
+
+map1.on('moveend zoomend', function () {
+  if (syncZoom) syncMap2();
+  updateUrl();
+});
+
+map2.on('moveend zoomend', function () {
+  if (syncZoom) syncMap1();
+  updateUrl();
+});
+
+const toggleBtn = document.getElementById('toggle-sync');
+function updateToggleText() {
+  toggleBtn.textContent = syncZoom ? 'Unsync zoom' : 'Sync zoom';
+}
+updateToggleText();
+
+toggleBtn.addEventListener('click', function () {
+  syncZoom = !syncZoom;
+  if (syncZoom) {
+    syncMap2();
+  }
+  updateToggleText();
+  updateUrl();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Map Compare</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-XQoYMqMTK8LvdxXYG3nZ384zl+xjmr1gsKW3w2ZK0Ek=" crossorigin="" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" integrity="sha256-mnW1YdZSAFDa0sxBz8cm/2yaCiyUS9iWO2fUADi5wGk=" crossorigin="" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="controls">
+    <button id="toggle-sync">Unsync zoom</button>
+    <button id="clear">Clear drawing</button>
+  </div>
+  <div id="maps">
+    <div id="map1" class="map"></div>
+    <div id="map2" class="map"></div>
+  </div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-oZhbE2Fv6XsuG2+hsM6alPolNPMBTMMwY1IanE2yEeE=" crossorigin=""></script>
+  <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js" integrity="sha256-ZJo2frbXyhF5zAwP0nrXyDqOiiN5Qc2aytYTPjvOrPo=" crossorigin=""></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+#maps {
+  display: flex;
+  height: calc(100% - 40px);
+}
+
+.map {
+  flex: 1;
+}
+
+#controls {
+  padding: 5px;
+  background: #eee;
+  height: 40px;
+}


### PR DESCRIPTION
## Summary
- add an `index.html` page with two synced Leaflet maps
- include drawing tools, clearing, sync toggle and URL updates
- style page layout with `style.css`
- implement logic and URL handling in `app.js`
- update `README`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688a30a94f74832ca96dfbffd98817d6