### PR TITLE
Add satellite map layer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # map-compare
 
-This project provides a small static website that helps comparing two places of the world side by side. The maps are powered by Leaflet with OpenStreetMap tiles.
+This project provides a small static website that helps comparing two places of the world side by side. The maps are powered by Leaflet with OpenStreetMap tiles by default but can be switched to satellite imagery.
 
 ## Usage
 
 Open `index.html` directly in a browser or host the repository with any static hosting solution such as GitHub Pages. The URL keeps the current map positions so copy‑pasting the address bar will restore the same views.
+It also stores whether map or satellite tiles are selected.

--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ function updateUrl() {
   url.searchParams.set('map1', `${c1.lat.toFixed(4)},${c1.lng.toFixed(4)},${z1}`);
   url.searchParams.set('map2', `${c2.lat.toFixed(4)},${c2.lng.toFixed(4)},${z2}`);
   url.searchParams.set('sync', syncZoom ? '1' : '0');
+  url.searchParams.set('layer', currentLayer);
   history.replaceState(null, '', url);
 }
 
@@ -27,16 +28,45 @@ const params = new URLSearchParams(window.location.search);
 const pos1 = parsePosition(params.get('map1')) || {lat: 0, lng: 0, zoom: 2};
 const pos2 = parsePosition(params.get('map2')) || pos1;
 syncZoom = params.get('sync') !== '0';
+let currentLayer = params.get('layer') === 'satellite' ? 'satellite' : 'map';
 
 const map1 = L.map('map1').setView([pos1.lat, pos1.lng], pos1.zoom);
 const map2 = L.map('map2').setView([pos2.lat, pos2.lng], pos2.zoom);
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+const osm1 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© OpenStreetMap contributors'
-}).addTo(map1);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+});
+const osm2 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© OpenStreetMap contributors'
-}).addTo(map2);
+});
+const sat1 = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+  attribution: 'Tiles © Esri'
+});
+const sat2 = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+  attribution: 'Tiles © Esri'
+});
+
+let baseLayer1;
+let baseLayer2;
+
+function setLayer(type) {
+  if (baseLayer1) map1.removeLayer(baseLayer1);
+  if (baseLayer2) map2.removeLayer(baseLayer2);
+  if (type === 'satellite') {
+    baseLayer1 = sat1;
+    baseLayer2 = sat2;
+  } else {
+    baseLayer1 = osm1;
+    baseLayer2 = osm2;
+  }
+  baseLayer1.addTo(map1);
+  baseLayer2.addTo(map2);
+  currentLayer = type;
+  document.getElementById('layer-select').value = type;
+  updateUrl();
+}
+
+setLayer(currentLayer);
 
 const drawnItems1 = new L.FeatureGroup();
 map1.addLayer(drawnItems1);
@@ -102,4 +132,8 @@ toggleBtn.addEventListener('click', function () {
   }
   updateToggleText();
   updateUrl();
+});
+
+document.getElementById('layer-select').addEventListener('change', function (e) {
+  setLayer(e.target.value);
 });

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   <div id="controls">
     <button id="toggle-sync">Unsync zoom</button>
     <button id="clear">Clear drawing</button>
+    <label for="layer-select">Tiles:</label>
+    <select id="layer-select">
+      <option value="map">Map</option>
+      <option value="satellite">Satellite</option>
+    </select>
   </div>
   <div id="maps">
     <div id="map1" class="map"></div>

--- a/style.css
+++ b/style.css
@@ -17,3 +17,7 @@ html, body {
   background: #eee;
   height: 40px;
 }
+
+#controls > * {
+  margin-right: 5px;
+}


### PR DESCRIPTION
## Summary
- add dropdown for selecting map or satellite tiles
- implement logic to switch base layers in `app.js`
- style controls spacing
- mention satellite option in README

## Testing
- `node -e "new Function(require('fs').readFileSync('app.js','utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_688a348fc778832ca444991deda49ad2