### PR TITLE
Improve header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,17 +9,20 @@
 </head>
 <body>
   <div id="header">
-    Compare any two locations side by side. Source code on
-    <a href="https://github.com/dbeley/map-compare">GitHub</a>.
-  </div>
-  <div id="controls">
-    <button id="toggle-sync">Unsync zoom</button>
-    <button id="clear">Clear drawing</button>
-    <label for="layer-select">Tiles:</label>
-    <select id="layer-select">
-      <option value="map">Map</option>
-      <option value="satellite">Satellite</option>
-    </select>
+    <div id="header-left">
+      <button id="toggle-sync">Unsync zoom</button>
+      <button id="clear">Clear drawing</button>
+      <label for="layer-select">Tiles:</label>
+      <select id="layer-select">
+        <option value="map">Map</option>
+        <option value="satellite">Satellite</option>
+      </select>
+    </div>
+    <div id="header-center">Map Compare</div>
+    <div id="header-right">
+      Compare any two locations side by side. Source code on
+      <a href="https://github.com/dbeley/map-compare">GitHub</a>.
+    </div>
   </div>
   <div id="maps">
     <div id="map1" class="map"></div>

--- a/style.css
+++ b/style.css
@@ -5,28 +5,38 @@ html, body {
 
 #maps {
   display: flex;
-  height: calc(100% - 80px);
+  height: calc(100% - 40px);
 }
 
 .map {
   flex: 1;
 }
 
-#controls {
-  padding: 5px;
-  background: #eee;
-  height: 40px;
-}
 
-#controls > * {
-  margin-right: 5px;
-}
 
 #header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 5px;
   background: #333;
   color: #fff;
   height: 40px;
+}
+
+#header-left > *,
+#header-right > * {
+  margin-right: 5px;
+}
+
+#header-center {
+  flex: 1;
+  text-align: center;
+  font-weight: bold;
+}
+
+#header-right {
+  white-space: nowrap;
 }
 
 #header a {


### PR DESCRIPTION
## Summary
- merge page header and controls into a single bar
- place controls on the left, title in the center, info on the right
- adjust map container height for the new header size

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a37e19a10832caca8bb18a4572e4e