### PR TITLE
Fix header link spacing

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -37,7 +37,7 @@ body {
   margin-right: 8px;
 }
 
-#header-right > * {
+#header-right > * + * {
   margin-left: 8px;
 }
 


### PR DESCRIPTION
## Summary
- update `#header-right` spacing rule to avoid large gap before the GitHub link

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a69fba024832c823abf6a01233246