### PR TITLE
Make header responsive on mobile

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -72,6 +72,27 @@ select {
 }
 
 @media (max-width: 600px) {
+  #header {
+    flex-direction: column;
+    align-items: center;
+    height: auto;
+    padding: 10px;
+    text-align: center;
+  }
+
+  #header-left,
+  #header-right {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 8px;
+  }
+
+  #header-left > *,
+  #header-right > * {
+    margin: 4px;
+  }
+
   #maps {
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- improve header layout on small screens by stacking sections and centering controls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dfee90fc0832ca4c20bfb7cded201