### PR TITLE
Allow localized map labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project provides a small static website that lets you compare two places of
 ## Usage
 
 Open `index.html` directly in a browser or host the repository with any static hosting solution such as GitHub Pages. The URL keeps the current map positions so copy‑pasting the address bar will restore the same views.
-It also stores whether map or satellite tiles are selected.
+It also stores whether map or satellite tiles are selected. Map labels follow your browser language by default; append `?lang=en` to force English names.
 
 Each shape has a blue drag handle at its center so you can reposition it at any time. The handle is always visible and works independently on each map. Shapes represent actual surface area so they grow or shrink as you zoom in or out. Once drawn a shape can't be edited, so redraw it if needed.
 When a new shape is created on the first map it is automatically duplicated on the second map at that map's current center so both panes show the drawing immediately. The duplicate is scaled to compensate for the Mercator projection's area distortion so you can compare actual surface areas at different latitudes. Use the trash button in the toolbar to delete individual shapes. The marker tool has been removed so only polygons, polylines and rectangles may be drawn.

--- a/docs/app.js
+++ b/docs/app.js
@@ -22,6 +22,7 @@ function updateUrl() {
   url.searchParams.set('map2', `${c2.lat.toFixed(4)},${c2.lng.toFixed(4)},${z2}`);
   url.searchParams.set('sync', syncZoom ? '1' : '0');
   url.searchParams.set('layer', currentLayer);
+  url.searchParams.set('lang', mapLang);
   history.replaceState(null, '', url);
 }
 
@@ -30,15 +31,18 @@ const pos1 = parsePosition(params.get('map1')) || {lat: 0, lng: 0, zoom: 2};
 const pos2 = parsePosition(params.get('map2')) || pos1;
 syncZoom = params.get('sync') !== '0';
 let currentLayer = params.get('layer') === 'satellite' ? 'satellite' : 'map';
+const defaultLang = (navigator.languages && navigator.languages[0]) || navigator.language || 'en';
+const mapLang = (params.get('lang') || defaultLang).split('-')[0];
 
 const map1 = L.map('map1').setView([pos1.lat, pos1.lng], pos1.zoom);
 const map2 = L.map('map2').setView([pos2.lat, pos2.lng], pos2.zoom);
 
-const osm1 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  attribution: '© OpenStreetMap contributors'
+const osmUrl = `https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png?lang=${mapLang}`;
+const osm1 = L.tileLayer(osmUrl, {
+  attribution: 'Wikimedia | © OpenStreetMap contributors'
 });
-const osm2 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  attribution: '© OpenStreetMap contributors'
+const osm2 = L.tileLayer(osmUrl, {
+  attribution: 'Wikimedia | © OpenStreetMap contributors'
 });
 const sat1 = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
   attribution: 'Tiles © Esri'


### PR DESCRIPTION
## Summary
- detect browser language and use localized OpenStreetMap tiles
- persist language preference in URL and docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dff40636c832c89d24cb0892802f6